### PR TITLE
Tag lang HTML dinamico in header.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -15,7 +15,7 @@ require_once get_template_directory() . '/walkers/mobile-header-walker.php';
 $theme_locations = get_nav_menu_locations();
 ?>
 <!doctype html>
-<html lang="it">
+<html <?php language_attributes(); ?>>
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
L'attributo lang nel tag html è impostato in modo statico in italiano, ma dovrebbe basarsi sulla lingua selezionata sulle impostazioni di WordPress, il che può variare con siti multilingua.

La funzione che ho aggiunto è una funzione nativa di WordPress, una funzione PHP standard che usano tutti i temi di WordPress.

## Descrizione

Sostituito \<html lang="it"\> con \<html \<?php language_attributes(); ?\>\>, funzione nativa di WordPress.

## Checklist

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).